### PR TITLE
fix(db): 'Schools' table is not found

### DIFF
--- a/class_sched_sys.sql
+++ b/class_sched_sys.sql
@@ -274,10 +274,10 @@ CREATE TABLE `schedules` (
 -- Table structure for table `schools`
 --
 
-DROP TABLE IF EXISTS `schools`;
+DROP TABLE IF EXISTS `Schools`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `schools` (
+CREATE TABLE `Schools` (
   `id` varchar(12) DEFAULT NULL,
   `name` varchar(120) NOT NULL,
   `total_terms_yearly` int DEFAULT NULL,


### PR DESCRIPTION
PROB: misspelled 'Schools' as 'schools'

FIX: fix misspelled word in models rather than in the views to make single change only

NOTE: if you already source the the sql file before you need to drop the schools table by `DROP TABLE schools` in mysql and source the updated sql file by `mysql -u root -p class_sched_sys < class_sched_sys.sql`