### PR TITLE
fix(db): source error at fresh install

### DIFF
--- a/class_sched_sys.sql
+++ b/class_sched_sys.sql
@@ -284,7 +284,7 @@ CREATE TABLE `Schedules` (
   CONSTRAINT `schedules_ibfk_2` FOREIGN KEY (`subj_id`) REFERENCES `Subjects` (`id`) ON DELETE CASCADE,
   CONSTRAINT `schedules_ibfk_3` FOREIGN KEY (`block_id`) REFERENCES `Blocks` (`id`) ON DELETE CASCADE,
   CONSTRAINT `schedules_ibfk_4` FOREIGN KEY (`faculty_id`) REFERENCES `Faculty` (`id`) ON DELETE SET NULL,
-  CONSTRAINT `schedules_ibfk_5` FOREIGN KEY (`room_id`) REFERENCES `Rooms` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `schedules_ibfk_5` FOREIGN KEY (`room_id`) REFERENCES `Rooms` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 


### PR DESCRIPTION
Error at sourcing/importing sql file to the database server at fresh install.

**Error Output**
![image](https://github.com/hijacque/class_timetable_web/assets/74945153/dbba7864-153c-4e13-a356-90fb487539ef)

**Reason**
Because of `,` at the end of the `CREATE TABLE`'s parameter at line 287

